### PR TITLE
update

### DIFF
--- a/hero1/package.xml
+++ b/hero1/package.xml
@@ -13,16 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  # hero-start
-  <exec_depend>hmi</exec_depend>
-  <exec_depend>text_to_speech</exec_depend>
-  <exec_depend>hero_bringup</exec_depend>
-  <exec_depend>hero_description</exec_depend>
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rosbridge_server</exec_depend>
-  <exec_depend>tue_mobile_ui</exec_depend>
-  <exec_depend>node_alive</exec_depend>
-  <exec_depend>head_ref</exec_depend>
+  <exec_depend>hero_start</exec_depend>
 
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>dragonfly_speech_recognition</exec_depend>
@@ -34,6 +25,6 @@
   <exec_depend>tue_teleop_keyboard</exec_depend>
 
   <export>
-     <metapackage />
+     <metapackage/>
   </export>
 </package>

--- a/hero1/package.xml
+++ b/hero1/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>hero1</name>
   <version>0.0.0</version>
   <description>The hero1 metapackage</description>

--- a/hero2/package.xml
+++ b/hero2/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>hero2</name>
   <version>0.0.0</version>
   <description>The hero2 metapackage</description>

--- a/hero2/package.xml
+++ b/hero2/package.xml
@@ -24,27 +24,6 @@
   <exec_depend>rgbd</exec_depend>
   <exec_depend>upower_ros</exec_depend>
 
-  # tue_middleware
-    <exec_depend>diagnostic_aggregator</exec_depend>
-    <exec_depend>node_alive</exec_depend>
-    <exec_depend>cb_base_navigation</exec_depend>
-    <exec_depend>dwa_local_planner</exec_depend>
-    <exec_depend>gmapping</exec_depend>
-    <exec_depend>ed</exec_depend>
-    <exec_depend>ed_object_models</exec_depend>
-    <exec_depend>ed_perception</exec_depend>
-    <exec_depend>ed_perception_models</exec_depend>
-    <exec_depend>ed_gui_server</exec_depend>
-    <exec_depend>ed_localization</exec_depend>
-    <exec_depend>ed_navigation</exec_depend>
-    <exec_depend>ed_robocup</exec_depend>
-    <exec_depend>ed_sensor_integration</exec_depend>
-    <exec_depend>ed_people_recognition</exec_depend>
-    <exec_depend>image_recognition</exec_depend>
-    <exec_depend>action_server</exec_depend>
-    <exec_depend>people_recognition</exec_depend>
-    <exec_depend>conversation_engine</exec_depend>
-
   # tue robocup at home
     <exec_depend>tue_robocup</exec_depend>
     <exec_depend>robocup_knowledge</exec_depend>

--- a/hero2/package.xml
+++ b/hero2/package.xml
@@ -24,9 +24,7 @@
   <exec_depend>rgbd</exec_depend>
   <exec_depend>upower_ros</exec_depend>
 
-  # tue robocup at home
-    <exec_depend>tue_robocup</exec_depend>
-    <exec_depend>robocup_knowledge</exec_depend>
+  <exec_depend>tue_robocup</exec_depend>
   <exec_depend>hero_skills</exec_depend>
   <exec_depend>telegram_ros</exec_depend>
   <exec_depend>image_recognition_openpose</exec_depend>

--- a/hero_dev/package.xml
+++ b/hero_dev/package.xml
@@ -10,19 +10,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  # simulator
+  <!-- simulator -->.
   <exec_depend>tmc_desktop_full</exec_depend>
+  
+  <exec_depend>tue_middleware</exec_depend>
+  <exec_depend>tue_mobile_ui</exec_depend>
 
   <exec_depend>rviz</exec_depend>
   <exec_depend>viz</exec_depend>
   <exec_depend>ed_rviz_plugins</exec_depend>
 
-  <exec_depend>hero_dashboard</exec_depend>
-  <exec_depend>hero_display</exec_depend> # How does this get on hero1?
-
-  <exec_depend>nl_robot_console</exec_depend> #should we also add this to the robots? for convenience?
+  <exec_depend>nl_robot_console</exec_depend>
 
   <export>
-     <metapackage />
+     <metapackage/>
   </export>
 </package>

--- a/hero_dev/package.xml
+++ b/hero_dev/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>hero_dev</name>
   <version>0.0.0</version>
   <description>The hero_dev metapackage, contains everything a hero development pc needs</description>

--- a/hero_dev/package.xml
+++ b/hero_dev/package.xml
@@ -15,7 +15,9 @@
 
   <!-- simulator -->.
   <exec_depend>tmc_desktop_full</exec_depend>
-  
+
+  <exec_depend>hero_start</exec_depend>
+
   <exec_depend>tue_middleware</exec_depend>
   <exec_depend>tue_mobile_ui</exec_depend>
 

--- a/hero_dev/package.xml
+++ b/hero_dev/package.xml
@@ -10,12 +10,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>hero1</exec_depend>
-  <exec_depend>hero2</exec_depend>
-
   # simulator
   <exec_depend>tmc_desktop_full</exec_depend>
-  <exec_depend>gazebo_plugins</exec_depend>
 
   <exec_depend>rviz</exec_depend>
   <exec_depend>viz</exec_depend>

--- a/hero_start/CMakeLists.txt
+++ b/hero_start/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(hero_start)
+
+find_package(catkin REQUIRED)
+
+catkin_metapackage()

--- a/hero_start/package.xml
+++ b/hero_start/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hero_start</name>
+  <version>0.0.0</version>
+  <description>The hero_start metapackage</description>
+
+  <maintainer email="amigo@todo.todo">amigo</maintainer>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>hmi</exec_depend>
+  <exec_depend>text_to_speech</exec_depend>
+  <exec_depend>hero_bringup</exec_depend>
+  <exec_depend>hero_description</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>tue_mobile_ui</exec_depend>
+  <exec_depend>node_alive</exec_depend>
+  <exec_depend>head_ref</exec_depend>
+
+  <export>
+     <metapackage/>
+  </export>
+</package>

--- a/tue_middleware/CMakeLists.txt
+++ b/tue_middleware/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(tue_middleware)
+
+find_package(catkin REQUIRED)
+
+catkin_metapackage()

--- a/tue_middleware/package.xml
+++ b/tue_middleware/package.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tue_middleware</name>
+  <version>0.0.0</version>
+  <description>The tue_middleware metapackage</description>
+
+  <maintainer email="amigo@todo.todo">amigo</maintainer>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>diagnostic_aggregator</exec_depend>
+  <exec_depend>node_alive</exec_depend>
+  <exec_depend>cb_base_navigation</exec_depend>
+  <exec_depend>depthimage_to_navscan_rgbd</exec_depend>
+  <exec_depend>dwa_local_planner</exec_depend>
+  <exec_depend>gmapping</exec_depend>
+  <exec_depend>ed</exec_depend>
+  <exec_depend>ed_object_models</exec_depend>
+  <exec_depend>ed_perception</exec_depend>
+  <exec_depend>ed_perception_models</exec_depend>
+  <exec_depend>ed_gui_server</exec_depend>
+  <exec_depend>ed_localization</exec_depend>
+  <exec_depend>ed_navigation</exec_depend>
+  <exec_depend>ed_robocup</exec_depend>
+  <exec_depend>ed_sensor_integration</exec_depend>
+  <exec_depend>ed_people_recognition</exec_depend>
+  <exec_depend>image_recognition</exec_depend>
+  <exec_depend>action_server</exec_depend>
+  <exec_depend>people_recognition</exec_depend>
+  <exec_depend>conversation_engine</exec_depend>
+
+  <export>
+     <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
`hero_bringup` and `hero_description` are both in `hero_start` and via the `hero-demo-user` in `hero2`. The `hero2` package still needs to be optimized, but this double dependency is not desired IMO.